### PR TITLE
Network creator without cfg

### DIFF
--- a/configs/ipt/denoise/val_denoise_50.yaml
+++ b/configs/ipt/denoise/val_denoise_50.yaml
@@ -5,9 +5,12 @@ system:
   context_mode: "pynative_mode"
   graph_kernel_flags: null
 
+# validator:
+#   name: "ipt_validator"
+
 model:
-  name: "ipt"
-  load_path: "/data/LLVT/IPT/ckpt/ipt_denoise50_ascend_v190_cbsd68_research_cv_acc29.9.ckpt"
+  name: "IPT_DENOISE"
+  load_path: "/home/tbaydasov/val_tests/models/LLVT/ckpt/IPT/ipt_denoise50_ascend_v190_cbsd68_research_cv_acc29.9.ckpt"
   is_training_finetune: false
   task_type: 'denoise'
   act: relu
@@ -62,7 +65,7 @@ task:
 # Dataset options
 dataset:
   dataset_name: "cbsd68"
-  input_path: "/data/LLVT/IPT/data/CBSD68"
+  input_path: "/home/tbaydasov/datasets/llvt_datasets/CBSD68"
   dataset_sink_mode: False
   train_annotation: null
   test_annotation: null
@@ -76,7 +79,7 @@ dataset:
   num_frames: null
   num_samples: null
   eval_batch_size: 1
-  num_parallel_workers: 8
+  num_parallel_workers: 4
   noise_level: 50
 
 # Common training options

--- a/mindediting/models/__init__.py
+++ b/mindediting/models/__init__.py
@@ -496,13 +496,13 @@ def create_model_by_name(model_name, cfg=None):
     return net, eval_network
 
 def get_model_info(model_name, cfg=None):
-    if not cfg:
+    if cfg is None:
         default_cfg_path = MODEL_NAME_TO_DEFAULT_INFO[model_name][1]
-        default_cfg, _, _ = parse_yaml(default_cfg_path)
-        default_cfg = Config(default_cfg)
-        default_cfg.model.load_path = None
+        cfg, _, _ = parse_yaml(default_cfg_path)
+        cfg = Config(default_cfg)
+        cfg.model.load_path = None
     model_creator_name = MODEL_NAME_TO_DEFAULT_INFO[model_name][0]
-    return default_cfg, model_creator_name
+    return cfg, model_creator_name
 
 
 


### PR DESCRIPTION
This implementation changes the "create_model_by_name" function to be able to load model using only one parameter: model_name. Config is changed to be optional.